### PR TITLE
Fix implicitly marking parameter as nullable deprecation

### DIFF
--- a/src/Nlp/BertTokenizer.php
+++ b/src/Nlp/BertTokenizer.php
@@ -406,7 +406,7 @@ class BertTokenizer
      * @return array
      * @throws \Exception
      */
-    public function encode(string $text, string $textPair = null, array $options = []): array {
+    public function encode(string $text, ?string $textPair = null, array $options = []): array {
         $addSpecialTokens = $options['add_special_tokens'] ?? true;
 
         $tokens = $this->encodeText($text);

--- a/src/VectorTable.php
+++ b/src/VectorTable.php
@@ -167,7 +167,7 @@ CREATE FUNCTION COSIM(v1 JSON, v2 JSON) RETURNS FLOAT DETERMINISTIC BEGIN DECLAR
      * @return int The ID of the inserted or updated vector
      * @throws \Exception If the vector could not be inserted or updated
      */
-    public function upsert(array $vector, int $id = null): int
+    public function upsert(array $vector, ?int $id = null): int
     {
         $magnitude = $this->getMagnitude($vector);
         $normalizedVector = $this->normalize($vector, $magnitude);
@@ -431,7 +431,7 @@ CREATE FUNCTION COSIM(v1 JSON, v2 JSON) RETURNS FLOAT DETERMINISTIC BEGIN DECLAR
      * @param float $epsilon The epsilon value to use for normalization
      * @return array The normalized vector
      */
-    private function normalize(array $vector, float $magnitude = null, float $epsilon = 1e-10): array {
+    private function normalize(array $vector, ?float $magnitude = null, float $epsilon = 1e-10): array {
         $magnitude = !empty($magnitude) ? $magnitude : $this->getMagnitude($vector);
         if ($magnitude == 0) {
             $magnitude = $epsilon;


### PR DESCRIPTION
As per https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated, in php 8.4 when a parameter has a default value of null, the type must be `?type` rather than `type`

Thanks!